### PR TITLE
 Replace Auto-Countdown with Manual Continue Button

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,8 @@
 
     <h1>Pong Game</h1>
     <div class="game-controls">
+           <!-- Added for continuing the game after a score, initially hidden -->
+    <button id="continueButton" style="display: none;">Continue</button>
         <button id="pauseButton">Pause</button>
         <label for="difficulty">Difficulty:</label>
         <select id="difficulty">
@@ -30,9 +32,11 @@
         <div class="score">
             <span id="playerScore">Player: 0</span> | <span id="aiScore">AI: 0</span>
         </div>
+     
     </div>
-    <canvas id="gameCanvas" width="600" height="400"></canvas>
 
+    <canvas id="gameCanvas" width="600" height="400"></canvas>
+    
     <script type="module" src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -40,6 +40,7 @@ let aiScore = 0;
 const minimumWinningScore = 3;
 const scoreDifferenceToWin = 2;
 
+let waitingForContinue = false; // Flag to track if waiting for continue button
 let gamePaused = true;
 let animationFrameId = null;
 let countdownActive = false;
@@ -55,6 +56,7 @@ const welcomeScreen = document.getElementById('welcomeScreen');
 const startGameButton = document.getElementById('startGameButton');
 const playerNameInput = document.getElementById('playerNameInput');
 const pauseButton = document.getElementById('pauseButton');
+const continueButton = document.getElementById('continueButton'); // Added continue button for resuming after a score
 const difficultySelect = document.getElementById('difficulty');
 const playerScoreDisplay = document.getElementById('playerScore');
 const aiScoreDisplay = document.getElementById('aiScore');
@@ -148,8 +150,12 @@ function moveEverything() {
             }, 500);
         } else {
             gamePaused = true;
+            pauseButton.style.display = 'none'; // Hide pause button
+            waitingForContinue = true; // Set flag to true
+            // Show continue button
+            continueButton.style.display = 'block';
             resetBall();
-            startCountdown();
+            
         }
     }
 
@@ -167,8 +173,12 @@ function moveEverything() {
             }, 500);
         } else {
             gamePaused = true;
+            pauseButton.style.display = 'none';
+            waitingForContinue = true; // Set flag to true
+            // Show continue button
+            continueButton.style.display = 'block';
             resetBall();
-            startCountdown();
+           
         }
     }
 
@@ -240,6 +250,8 @@ function resetGame() {
 
     gamePaused = true;
     pauseButton.textContent = "Resume";
+    waitingForContinue = false; // Reset flag
+    continueButton.style.display = 'none'; // Hide continue button
 
     if (animationFrameId) {
         cancelAnimationFrame(animationFrameId);
@@ -474,5 +486,16 @@ canvas.addEventListener('mousemove', (evt) => {
 
         if (playerPaddleY < 0) playerPaddleY = 0;
         if (playerPaddleY + paddleHeight > canvas.height) playerPaddleY = canvas.height - paddleHeight;
+    }
+});
+// Event listener for continue button to resume the game
+continueButton.addEventListener('click', () => {
+    if(waitingForContinue) {
+        waitingForContinue = false; // Reset flag
+        continueButton.style.display = 'none'; // Hide continue button
+        gamePaused = false; // Resume the game
+        pauseButton.textContent = "Pause"; // Update pause button text
+        pauseButton.style.display = 'block'; // Show pause button again
+
     }
 });

--- a/style.css
+++ b/style.css
@@ -189,3 +189,19 @@ h1 {
         font-size: 1.1em;
     }
 }
+
+/* Continue button styles */
+#continueButton {
+    padding: 8px 15px;
+    font-size: 1em;
+    cursor: pointer;
+    background-color: #2a804e;
+    color: white;
+    border: none;
+    border-radius: 5px;
+    transition: background-color 0.3s ease;
+}
+
+#continueButton:hover {
+    background-color: #0d3910;
+}


### PR DESCRIPTION
issue number: #5 
Description:
Description:
This PR introduces player-controlled game flow by replacing the automatic countdown after scoring with a manual "Continue" button (Issue #5).

Key changes include:
-Removed forced countdown after each score
-Implemented a 'Continue' button that appears in place of the pause/resume button after scoring
-Maintained responsive UI - the continue button seamlessly replaces the pause/resume button to ensure proper display across all screen sizes
-Restored pause/resume button functionality when gameplay continues

Why this change?
-Gives players control over when to resume play
-Eliminates disruptive automatic countdowns
-Preserves clean UI by reusing button placement
-Maintains responsive design for all screen sizes
<img width="987" height="816" alt="image" src="https://github.com/user-attachments/assets/c60639eb-34d7-48c2-a87b-d54c73a9d125" />
