### PR TITLE
Fix #13: Change ball color to blue

### DIFF
--- a/script.js
+++ b/script.js
@@ -103,7 +103,7 @@ function drawEverything() {
 
     ctx.beginPath();
     ctx.arc(ballX, ballY, ballRadius, 0, Math.PI * 2, false);
-    ctx.fillStyle = 'white';
+    ctx.fillStyle = 'blue';
     ctx.fill();
 
     // Draw countdown number ONLY if active


### PR DESCRIPTION
### What does this PR do?
This pull request updates the ball color in the `drawEverything()` function from white to blue as requested in issue #13.

### Changes Made
- Updated `ctx.fillStyle = 'white'` to `ctx.fillStyle = 'blue'` in `script.js` where the ball is drawn.

### Related Issue
Closes #13

### Additional Notes
Let me know if you'd like the color to be configurable based on difficulty or theme.
