### PR TITLE
Added game mode selection UI

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5501
+}

--- a/index.html
+++ b/index.html
@@ -10,8 +10,31 @@
     <div id="welcomeScreen" class="welcome-screen">
         <h2>Welcome to Pong!</h2>
         <input type="text" id="playerNameInput" placeholder="Enter your name (optional)" maxlength="15">
-        <button id="startGameButton">Play Game</button>
-    </div>
+ 
+    <!-- Game Mode Selector -->
+    <div class="game-mode-options">
+        <label class="mode-option">
+            <input type="radio" name="mode" value="pve_easy" checked>
+            Player vs AI <small>(Easy)</small>
+        </label>
+        <label class="mode-option">
+            <input type="radio" name="mode" value="pve_hard">
+            Player vs AI <small>(Hard)</small>
+        </label>
+        <label class="mode-option">
+            <input type="radio" name="mode" value="pvp">
+            Player vs Player
+        </label>
+        <label class="mode-option">
+            <input type="radio" name="mode" value="aivai">
+            AI vs AI <small>(Spectator)</small>
+        </label>
+     </div>
+
+       <div class="play-button-wrapper">
+              <button id="startGameButton">Play Game</button>
+             </div>
+     </div>
 
     <div id="gameOverScreen" class="game-over-screen">
         <h2 id="gameOverMessage"></h2>

--- a/style.css
+++ b/style.css
@@ -65,6 +65,45 @@ body::before {
     }
 }
 
+.game-mode-options {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  margin-top: 20px;
+}
+
+.mode-option {
+  background: rgba(255, 255, 255, 0.05);
+  border: 2px solid transparent;
+  border-radius: 25px;
+  padding: 12px 24px;
+  cursor: pointer;
+  font-size: 16px;
+  color: white;
+  transition: all 0.3s ease;
+  text-align: center;
+  width: 220px;
+  user-select: none;
+}
+.mode-option input[type="radio"]:checked + * {
+  border-color: #00ffd5;
+  background-color: rgba(0, 255, 213, 0.1);
+  box-shadow: 0 0 10px #00ffd5;
+}
+
+.mode-option input[type="radio"] {
+  display: none;
+}
+.mode-option small {
+  font-size: 13px;
+  color: #aaa;
+  margin-left: 6px;
+}
+.play-button-wrapper {
+  margin-top: 30px;
+}
+
 canvas {
     background: linear-gradient(135deg, #1e3c72 0%, #2a5298 50%, #1e3c72 100%);
     border: 2px solid rgba(255, 255, 255, 0.3);


### PR DESCRIPTION
Created the frontend UI for selecting game modes:
- Player vs AI (Easy/Medium/Hard)
- Player vs Player
- AI vs AI
- Kept layout responsive and consistent with original style
- Positioned mode selector below name input

Tested On:
- Desktop & Mobile view
- Verified game mode selection appears and Play Game button works

The Play Game button is linked, but logic integration is pending.
Designed to be responsive and clean, based on design discussions.




<img width="1920" height="1080" alt="Screenshot 2025-07-25 105927" src="https://github.com/user-attachments/assets/6dfe5fca-0b4a-46a7-b718-9106a5327d8c" />

@nidhi829n can now begin backend integration from this base.
