### PR TITLE
Feat/audio keyboard shortcuts

### DIFF
--- a/audio.js
+++ b/audio.js
@@ -59,3 +59,14 @@ export function stopBackgroundMusicRotation() {
         // No console.log
     }
 }
+
+// --- Volume and Mute Controls ---
+export function setMusicVolume(vol) {
+    backgroundMusicTracks.forEach(track => track.volume = vol);
+}
+export function muteMusic() {
+    backgroundMusicTracks.forEach(track => track.volume = 0);
+}
+export function unmuteMusic(vol) {
+    backgroundMusicTracks.forEach(track => track.volume = vol);
+}

--- a/index.html
+++ b/index.html
@@ -19,6 +19,13 @@
         <button id="playAgainButton">Play Again</button>
     </div>
 
+    <div id="pauseMenu" class="pause-menu" style="display:none;">
+        <h2>Paused</h2>
+        <button id="resumeButton">Resume</button>
+        <button id="restartButton">Restart</button>
+        <button id="exitButton">Exit to Menu</button>
+    </div>
+
     <h1>Pong Game</h1>
     <div class="game-controls">
         <button id="pauseButton">Pause</button>

--- a/index.html
+++ b/index.html
@@ -26,6 +26,15 @@
         <button id="exitButton">Exit to Menu</button>
     </div>
 
+    <div class="audio-controls" style="margin: 20px 0; text-align: center;">
+        <label style="margin-right: 20px;">
+            Music Volume
+            <input type="range" id="musicVolume" min="0" max="1" step="0.01" value="1">
+            <button id="musicMute">Mute</button>
+        </label>
+
+    </div>
+
     <h1>Pong Game</h1>
     <div class="game-controls">
         <button id="pauseButton">Pause</button>

--- a/script.js
+++ b/script.js
@@ -9,7 +9,10 @@ import {
     gameOverSound,
     playerWinSound,
     countdownBeepSound,
-    backgroundMusicTracks
+    backgroundMusicTracks,
+    setMusicVolume,
+    muteMusic,
+    unmuteMusic
 } from './audio.js';
 
 const canvas = document.getElementById('gameCanvas');
@@ -47,7 +50,7 @@ let countdownValue = 3;
 
 // Global variable to store the countdown interval ID
 let countdownIntervalId = null;
-
+let lastFrameTime = performance.now();
 let playerName = "Player";
 
 // DOM elements
@@ -414,31 +417,7 @@ function handleTouchMove(event) {
     }
 }
 
-// Update pauseButton event listener to show pause menu
-pauseButton.addEventListener('click', () => {
-    if (!countdownActive && gameState === GAME_STATES.PLAYING) {
-        gamePaused = true;
-        gameState = GAME_STATES.PAUSED;
-        pauseButton.textContent = "Resume";
-        if (animationFrameId) {
-            cancelAnimationFrame(animationFrameId);
-            animationFrameId = null;
-        }
-        stopBackgroundMusicRotation();
-        showPauseMenu(true);
-    } else if (gameState === GAME_STATES.PAUSED) {
-        // Resume from pause
-        gamePaused = false;
-        gameState = GAME_STATES.PLAYING;
-        pauseButton.textContent = "Pause";
-        startBackgroundMusicRotation();
-        showPauseMenu(false);
-        if (!countdownActive) {
-            lastFrameTime = performance.now();
-            requestAnimationFrame(gameLoop);
-        }
-    }
-});
+
 
 // Resume button
 resumeButton.addEventListener('click', () => {
@@ -461,6 +440,7 @@ restartButton.addEventListener('click', () => {
     gameState = GAME_STATES.PLAYING;
     pauseButton.textContent = "Pause";
     startBackgroundMusicRotation();
+    ensureMusicMuteState(); // Ensure music mute state is applied
     lastFrameTime = performance.now();
     requestAnimationFrame(gameLoop);
 });
@@ -519,7 +499,13 @@ document.addEventListener('DOMContentLoaded', () => {
     aiPaddleY = (canvas.height - paddleHeight) / 2;
     drawEverything(); // Draw initial state on canvas
 });
-
+function ensureMusicMuteState() {
+    if (musicMuted) {
+        muteMusic();
+        musicMuteBtn.textContent = 'Unmute';
+        musicVolumeSlider.value = 0;
+    }
+}
 // Minor adjustment in startGameButton to set gameState
 startGameButton.addEventListener('click', () => {
     playerName = playerNameInput.value.trim();
@@ -529,8 +515,10 @@ startGameButton.addEventListener('click', () => {
     welcomeScreen.style.display = 'none';
     gameState = GAME_STATES.PLAYING; // Set game state to playing
     startBackgroundMusicRotation();
+    ensureMusicMuteState(); // Ensure music mute state is applied
     resetGame();
     startCountdown();
+    showPauseMenu(false); // Hide pause menu on game start
 });
 
 // Minor adjustment in playAgainButton to set gameState
@@ -539,6 +527,7 @@ playAgainButton.addEventListener('click', () => {
     gameState = GAME_STATES.PLAYING; // Set game state to playing
     resetGame();
     startBackgroundMusicRotation();
+    ensureMusicMuteState(); // Ensure music mute state is applied
     startCountdown();
 });
 
@@ -548,17 +537,21 @@ pauseButton.addEventListener('click', () => {
         if (gameState === GAME_STATES.PLAYING) {
             gamePaused = true;
             gameState = GAME_STATES.PAUSED; // Set game state to paused
+           // console.log('Paused! gameState:', gameState);
             pauseButton.textContent = "Resume";
             if (animationFrameId) {
                 cancelAnimationFrame(animationFrameId);
                 animationFrameId = null;
             }
             stopBackgroundMusicRotation();
+            showPauseMenu(true); // Show pause menu
         } else if (gameState === GAME_STATES.PAUSED) {
             gamePaused = false;
             gameState = GAME_STATES.PLAYING; // Set game state to playing
+            //console.log('Resumed! gameState:', gameState);
             pauseButton.textContent = "Pause";
             startBackgroundMusicRotation();
+            showPauseMenu(false);
             if (!countdownActive) {
                  startCountdown();
             } else {
@@ -616,3 +609,56 @@ function keyboardPaddleControl() {
     if (playerPaddleY < 0) playerPaddleY = 0;
     if (playerPaddleY + paddleHeight > canvas.height) playerPaddleY = canvas.height - paddleHeight;
 }
+
+// Audio controls wiring
+const musicVolumeSlider = document.getElementById('musicVolume');
+const musicMuteBtn = document.getElementById('musicMute');
+let musicMuted = false;
+let lastMusicVolume = 1;
+musicVolumeSlider.addEventListener('input', (e) => {
+    const vol = parseFloat(e.target.value);
+    setMusicVolume(vol);
+    if (vol === 0) {
+        musicMuted = true;
+        musicMuteBtn.textContent = 'Unmute';
+    } else {
+        musicMuted = false;
+        musicMuteBtn.textContent = 'Mute';
+        lastMusicVolume = vol;
+    }
+});
+musicMuteBtn.addEventListener('click', () => {
+    if (!musicMuted) {
+        muteMusic();
+        musicMuted = true;
+        musicMuteBtn.textContent = 'Unmute';
+    } else {
+        unmuteMusic(lastMusicVolume);
+        musicMuted = false;
+        musicMuteBtn.textContent = 'Mute';
+        musicVolumeSlider.value = lastMusicVolume;
+    }
+});
+
+// Pause menu keyboard shortcuts
+// Esc: pause/resume, R: restart, M: exit to menu (when paused)
+document.addEventListener('keydown', (e) => {
+    console.log(`Key pressed: ${e.key},gameState: ${gameState}`); // Debugging line to see key presses
+    if (e.key === 'Escape') {
+        if (gameState === GAME_STATES.PLAYING) {
+            // Pause
+            pauseButton.click();
+        } else if (gameState === GAME_STATES.PAUSED) {
+            // Resume
+            resumeButton.click();
+        }
+    }
+    if (gameState === GAME_STATES.PAUSED) {
+        if (e.key.toLowerCase() === 'r') {
+            restartButton.click();
+        }
+        if (e.key.toLowerCase() === 'm') {
+            exitButton.click();
+        }
+    }
+});

--- a/style.css
+++ b/style.css
@@ -279,6 +279,61 @@ h1 {
     filter: drop-shadow(0 0 10px rgba(255, 215, 0, 0.5));
 }
 
+.pause-menu {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.3);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    display: none; /* Hidden by default, shown by JS */
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    z-index: 100;
+    text-align: center;
+    padding: 20px;
+    box-sizing: border-box;
+}
+
+.pause-menu h2 {
+    font-size: 2.5em;
+    margin-bottom: 30px;
+    background: linear-gradient(45deg, #4ecdc4, #45b7d1, #96ceb4);
+    background-size: 200% 200%;
+    animation: gradientShift 4s ease infinite;
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    text-shadow: 0 0 30px rgba(76, 205, 196, 0.8);
+    filter: drop-shadow(0 0 10px rgba(76, 205, 196, 0.5));
+}
+
+.pause-menu button {
+    padding: 12px 20px;
+    font-size: 1em;
+    cursor: pointer;
+    background: rgba(255, 255, 255, 0.15);
+    color: white;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    border-radius: 12px;
+    transition: all 0.3s ease;
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    box-shadow: 0 4px 15px 0 rgba(31, 38, 135, 0.3);
+    font-weight: 500;
+    margin: 10px 0;
+}
+
+.pause-menu button:hover {
+    background: rgba(255, 255, 255, 0.25);
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px 0 rgba(31, 38, 135, 0.4);
+    border-color: rgba(255, 255, 255, 0.5);
+}
+
 /* Add enhanced styling for better game element visibility */
 canvas:hover {
     transform: scale(1.02);

--- a/style.css
+++ b/style.css
@@ -280,58 +280,42 @@ h1 {
 }
 
 .pause-menu {
-    position: absolute;
+    position: fixed;
     top: 0;
     left: 0;
-    width: 100%;
-    height: 100%;
-    background: rgba(0, 0, 0, 0.3);
-    backdrop-filter: blur(20px);
-    -webkit-backdrop-filter: blur(20px);
-    display: none; /* Hidden by default, shown by JS */
+    width: 100vw;
+    height: 100vh;
+    background: rgba(20, 20, 40, 0.85);
+    display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    z-index: 100;
-    text-align: center;
-    padding: 20px;
-    box-sizing: border-box;
+    z-index: 1000;
+    backdrop-filter: blur(8px);
 }
-
 .pause-menu h2 {
-    font-size: 2.5em;
+    color: #fff;
+    font-size: 2.2em;
     margin-bottom: 30px;
-    background: linear-gradient(45deg, #4ecdc4, #45b7d1, #96ceb4);
-    background-size: 200% 200%;
-    animation: gradientShift 4s ease infinite;
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    text-shadow: 0 0 30px rgba(76, 205, 196, 0.8);
-    filter: drop-shadow(0 0 10px rgba(76, 205, 196, 0.5));
 }
-
 .pause-menu button {
-    padding: 12px 20px;
-    font-size: 1em;
-    cursor: pointer;
-    background: rgba(255, 255, 255, 0.15);
-    color: white;
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    padding: 14px 28px;
+    font-size: 1.1em;
+    margin: 12px 0;
+    background: rgba(255,255,255,0.15);
+    color: #fff;
+    border: 1px solid rgba(255,255,255,0.3);
     border-radius: 12px;
-    transition: all 0.3s ease;
-    backdrop-filter: blur(10px);
-    -webkit-backdrop-filter: blur(10px);
-    box-shadow: 0 4px 15px 0 rgba(31, 38, 135, 0.3);
+    cursor: pointer;
+    transition: all 0.3s;
     font-weight: 500;
-    margin: 10px 0;
+    box-shadow: 0 4px 15px 0 rgba(31,38,135,0.3);
 }
-
 .pause-menu button:hover {
-    background: rgba(255, 255, 255, 0.25);
+    background: rgba(255,255,255,0.25);
     transform: translateY(-2px);
-    box-shadow: 0 6px 20px 0 rgba(31, 38, 135, 0.4);
-    border-color: rgba(255, 255, 255, 0.5);
+    box-shadow: 0 6px 20px 0 rgba(31,38,135,0.4);
+    border-color: rgba(255,255,255,0.5);
 }
 
 /* Add enhanced styling for better game element visibility */

--- a/style.css
+++ b/style.css
@@ -345,6 +345,41 @@ canvas:hover {
     transform: scale(1.05);
 }
 
+.audio-controls {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 40px;
+    margin-bottom: 20px;
+}
+.audio-controls label {
+    color: #fff;
+    font-size: 1.1em;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+.audio-controls input[type="range"] {
+    width: 120px;
+    accent-color: #4fc3f7;
+    margin: 0 8px;
+}
+.audio-controls button {
+    padding: 6px 16px;
+    font-size: 1em;
+    background: rgba(255,255,255,0.12);
+    color: #fff;
+    border: 1px solid rgba(255,255,255,0.25);
+    border-radius: 8px;
+    cursor: pointer;
+    transition: all 0.2s;
+    margin-left: 8px;
+}
+.audio-controls button:hover {
+    background: rgba(255,255,255,0.22);
+    border-color: rgba(255,255,255,0.4);
+}
+
 /* --- Media Queries for Smaller Screens (Key for Responsiveness) --- */
 @media (max-width: 768px) {
     h1 {


### PR DESCRIPTION
Addresses #57 
Parent issue #43 
**Added keyboard shortcuts for pause menu:**

- Esc to pause/resume
- R to restart
- M to exit to menu

1. Pause menu now correctly sets game state to [PAUSED] and shows/hides as expected.
2. Mute state for  music is now persistent across rounds and restarts.
3. Improved event handling and removed duplicate listeners.
4. Fixed issues where shortcuts didn’t work due to incorrect game state.

## Related Commits

- feat/audio-keyboard-shortcuts: f608ab77cc72e2916dde5fcb3670cd70aea91563