### PR TITLE
Fixed arrow key select input issue(Closes Issue #83)

### DIFF
--- a/script.js
+++ b/script.js
@@ -508,6 +508,8 @@ pauseButton.addEventListener('click', () => {
 // Adjust difficultySelect event listener to use gameState
 difficultySelect.addEventListener('change', (event) => {
     difficultyLevel = event.target.value;
+    // Immediately removes the focus from the select input so that the arrow up/down keys don't interfere with it
+    event.target.blur();
     resetGame();
     // Only start countdown if the game was actively playing or paused (not on welcome/game over)
     if (gameState === GAME_STATES.PLAYING || gameState === GAME_STATES.PAUSED) {


### PR DESCRIPTION
**Fixes #83**

This PR addresses the issue where changing the game difficulty caused continuous unexpected behavior when using arrow keys for paddle movement.

The root cause was that after selecting a difficulty, the `<select>` input element retained focus. Consequently, subsequent presses of the `ArrowUp` or `ArrowDown` keys, intended for paddle control, were instead intercepted by the focused `difficultySelect` element, causing it to cycle through options and trigger repeated game resets.

To resolve this, I've added `event.target.blur();` within the `difficultySelect` event listener. This ensures that focus is removed from the difficulty dropdown immediately after a selection is made, preventing interference with the paddle movement controls. I have also added a comment along with it in the code to explain the changes made. 

---

**Fixed Gameplay**

https://github.com/user-attachments/assets/2c05a0b4-c789-40d9-8a22-c6e493c15952

---

**I am a GSSOC'25 Contributor. Please review and merge my PR and then update my points accordingly.**