### PR TITLE
Fix: Improved dropdown contrast for better accessibility

### DIFF
--- a/style.css
+++ b/style.css
@@ -227,8 +227,8 @@ h1 {
 }
 
 .game-controls select option {
-    background: var(--button-bg);
-    color: var(--text-color);
+    background: var(--dropdown-bg);
+    color: var(--dropdown-color);
 }
 
 /* Enhanced dropdown for better theme consistency */

--- a/themes.css
+++ b/themes.css
@@ -41,6 +41,8 @@
     --button-border: rgba(255, 255, 255, 0.3);
     --button-hover-bg: rgba(255, 255, 255, 0.25);
     --button-hover-border: rgba(255, 255, 255, 0.5);
+    --dropdown-bg: #1e1e2f;
+    --dropdown-color: white;
     
     /* Screen overlays */
     --overlay-bg: rgba(0, 0, 0, 0.3);
@@ -94,6 +96,8 @@
     --button-border: rgba(0, 255, 255, 0.5);
     --button-hover-bg: rgba(0, 255, 255, 0.35);
     --button-hover-border: rgba(0, 255, 255, 0.8);
+    --dropdown-bg: #000;
+    --dropdown-color: #FF6B6B;
     
     /* Screen overlays */
     --overlay-bg: rgba(0, 0, 0, 0.7);
@@ -147,6 +151,8 @@
     --button-border: rgba(128, 128, 128, 0.4);
     --button-hover-bg: rgba(128, 128, 128, 0.3);
     --button-hover-border: rgba(255, 255, 255, 0.6);
+    --dropdown-bg: #1e1e2f;
+    --dropdown-color: white;
     
     /* Screen overlays */
     --overlay-bg: rgba(0, 0, 0, 0.8);
@@ -200,6 +206,8 @@
     --button-border: rgba(0, 191, 255, 0.4);
     --button-hover-bg: rgba(0, 191, 255, 0.25);
     --button-hover-border: rgba(0, 255, 255, 0.6);
+    --dropdown-bg: #0a3d62;
+    --dropdown-color: #80cae5;
     
     /* Screen overlays */
     --overlay-bg: rgba(0, 17, 34, 0.6);


### PR DESCRIPTION
**This PR fixes the dropdown visibility and contrast issue in the game controls section — especially for the theme and difficulty selectors.** #159

**What was the issue?**
In some themes, the dropdown options were hard to read while hovering or focusing, due to poor color contrast. This made it difficult for users to select options clearly.

**What’s changed?**
Created a new branch: fix/dropdown-contrast

Improved the CSS for dropdown <option> elements on hover and focus

Made sure the changes work well with different themes

📌 Extra Notes
This PR is submitted as part of GSSoC '25 for a currently assigned issue.
Screenshots of the changes are added below.
If there are any suggestions or feedback, feel free to share!

Before:
<img width="533" height="494" alt="image" src="https://github.com/user-attachments/assets/5650a2bd-fce4-4bb5-aec5-b86cb520709a" />

After: (Theme Specific)
<img width="704" height="380" alt="Screenshot 2025-08-06 104758" src="https://github.com/user-attachments/assets/a09d3ac7-a9ce-4fc6-9af8-418dedecf281" />


<img width="638" height="442" alt="Screenshot 2025-08-06 104908" src="https://github.com/user-attachments/assets/82b54d38-bd11-4f7b-804f-c391c7dfe331" />

<img width="569" height="430" alt="Screenshot 2025-08-06 104857" src="https://github.com/user-attachments/assets/7f36ff6a-f132-40ad-a14e-2dfadcd63325" />
