### PR TITLE
updated readme to show live count of fork and stars on the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # 🎾 Classic Pong Game with Modern Touches 🚀
 
+<div align="center">
+<a href="https://github.com/Akki-jaiswal/pong-game/stargazers">
+  <img src="https://img.shields.io/github/stars/Akki-jaiswal/pong-game?style=social" alt="GitHub Stars">
+</a>
+<a href="https://github.com/Akki-jaiswal/pong-game/forks">
+  <img src="https://img.shields.io/github/forks/Akki-jaiswal/pong-game?style=social" alt="GitHub Forks">
+</a>
+</div>
+
 Relive the nostalgia of a retro classic! This project is a straightforward yet engaging implementation of the iconic Pong game, built using core web technologies: HTML, CSS, and JavaScript. It features an AI opponent, adjustable difficulty, interactive elements, full responsiveness, and touch controls to provide a fun and familiar experience for all players.
 
 ## ✨ Key Features


### PR DESCRIPTION
### Pull Request: Add live Stars and Forks count for the repo

**Closes #226**  

#### Changes Made  
- Added **GitHub Stars** and **Forks**  badges to the top of the README.  
- Wrapped the badges inside a `<div align="center">` for a clean, centered layout.  

#### Screenshots (Preview)  
**Before:**  
<img width="1303" height="392" alt="image" src="https://github.com/user-attachments/assets/c216575b-b60b-43be-9ecc-c5bfc0049de1" />

Badges were not present in the README.  

**After:**  
<img width="1330" height="472" alt="image" src="https://github.com/user-attachments/assets/0aa08249-4c93-4262-a687-dc53340dcca2" />

Badges now appear centered right below the project title.  


#### Why This Change?  
- Makes the README more visually appealing.  
- Highlights repo popularity (Stars/Forks) prominently for contributors and new visitors.  
